### PR TITLE
Update clean up logic

### DIFF
--- a/src/ReceiveSharingIntent.ts
+++ b/src/ReceiveSharingIntent.ts
@@ -33,7 +33,9 @@ class ReceiveSharingIntentModule implements IReceiveSharingIntent {
     }
 
     clearReceivedFiles(){
-        this.isClear = true;
+        // https://github.com/ajith-ab/react-native-receive-sharing-intent/issues/149
+        // this.isClear = true;
+        ReceiveSharingIntent.clearFileNames();
     }
 
     


### PR DESCRIPTION
Feature updates `clearReceivedFiles` based on suggestions I found on main repo issues.
It would often happen that sharing modal opened only once, no matter where I moved the unmounting logic, and this fixes that issue.