### PR TITLE
Update clearFileNames

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -488,7 +488,9 @@ public class ReceiveSharingIntentHelper {
     } else if (
       type.startsWith("image") ||
       type.startsWith("video") ||
-      type.startsWith("application")
+      type.startsWith("application") ||
+      // */* covers case when Video and Images were shared together
+      type.startsWith("*/*")
     ) {
       intent.removeExtra(Intent.EXTRA_STREAM);
     }


### PR DESCRIPTION
Properly covered the case when both videos and images are shared together.