### PR TITLE
Update Android Exif resolving

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,9 +33,8 @@ android {
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-    
   }
-  
+
   buildTypes {
     release {
       minifyEnabled false
@@ -127,4 +126,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "androidx.exifinterface:exifinterface:1.3.6"
 }

--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
-import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -17,6 +16,7 @@ import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
 import com.facebook.react.bridge.*;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -36,13 +36,12 @@ public class ReceiveSharingIntentHelper {
     this.context = context;
   }
 
-  // https://developer.android.com/reference/androidx/exifinterface/media/ExifInterface#constants
+  // https://developer.android.com/reference/androidx/exifinterface/media/ExifInterface
   private static final String[] EXIF_ATTRIBUTES = new String[] {
     ExifInterface.TAG_DATETIME,
     ExifInterface.TAG_DATETIME_ORIGINAL,
     ExifInterface.TAG_IMAGE_LENGTH,
     ExifInterface.TAG_IMAGE_WIDTH,
-    ExifInterface.TAG_APERTURE,
     ExifInterface.TAG_DATETIME_DIGITIZED,
     ExifInterface.TAG_EXPOSURE_TIME,
     ExifInterface.TAG_FLASH,
@@ -56,15 +55,12 @@ public class ReceiveSharingIntentHelper {
     ExifInterface.TAG_GPS_LONGITUDE_REF,
     ExifInterface.TAG_GPS_PROCESSING_METHOD,
     ExifInterface.TAG_GPS_TIMESTAMP,
-    ExifInterface.TAG_ISO,
     ExifInterface.TAG_MAKE,
     ExifInterface.TAG_MODEL,
     ExifInterface.TAG_ORIENTATION,
     ExifInterface.TAG_X_RESOLUTION,
     ExifInterface.TAG_Y_RESOLUTION,
     ExifInterface.TAG_SUBSEC_TIME,
-    ExifInterface.TAG_SUBSEC_TIME_DIG,
-    ExifInterface.TAG_SUBSEC_TIME_ORIG,
     ExifInterface.TAG_WHITE_BALANCE,
     ExifInterface.TAG_BITS_PER_SAMPLE,
     ExifInterface.TAG_COMPRESSED_BITS_PER_PIXEL,
@@ -228,8 +224,9 @@ public class ReceiveSharingIntentHelper {
             queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
           )
         );
-      } catch (Exception e) {}
-
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
       file.putMap("exif", exif);
 
       files.putMap("0", file);

--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -179,6 +179,7 @@ public class ReceiveSharingIntentHelper {
     } catch (Exception ignored) {}
 
     WritableMap files = new WritableNativeMap();
+
     if (Objects.equals(intent.getAction(), Intent.ACTION_SEND)) {
       WritableMap file = new WritableNativeMap();
       Uri contentUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
@@ -203,6 +204,10 @@ public class ReceiveSharingIntentHelper {
           queryResult.getColumnIndex(OpenableColumns.DISPLAY_NAME)
         )
       );
+      file.putString(
+        "fileSize",
+        queryResult.getString(queryResult.getColumnIndex(OpenableColumns.SIZE))
+      );
       file.putString("filePath", filePath);
       file.putString("contentUri", contentUri.toString());
       file.putString("text", null);
@@ -210,22 +215,20 @@ public class ReceiveSharingIntentHelper {
       file.putString("subject", subject);
 
       WritableMap exif = getExif(contentUri.toString());
-      exif.putString(
-        "DateTimeModified",
-        queryResult.getString(
-          queryResult.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
-        )
-      );
-      exif.putString(
-        "ImageOrientation",
-        queryResult.getString(
-          queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-        )
-      );
-
-      File tempFile = new File(filePath);
-      long fileSize = tempFile.length();
-      file.putInt("fileSize", Math.toIntExact(fileSize));
+      try {
+        exif.putString(
+          "DateTimeModified",
+          queryResult.getString(
+            queryResult.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
+          )
+        );
+        exif.putString(
+          "ImageOrientation",
+          queryResult.getString(
+            queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+          )
+        );
+      } catch (Exception e) {}
 
       file.putMap("exif", exif);
 
@@ -262,6 +265,12 @@ public class ReceiveSharingIntentHelper {
               queryResult.getColumnIndex(OpenableColumns.DISPLAY_NAME)
             )
           );
+          file.putString(
+            "fileSize",
+            queryResult.getString(
+              queryResult.getColumnIndex(OpenableColumns.SIZE)
+            )
+          );
           file.putString("filePath", filePath);
           file.putString("contentUri", uri.toString());
           file.putString("text", null);
@@ -269,24 +278,25 @@ public class ReceiveSharingIntentHelper {
           file.putString("subject", subject);
 
           WritableMap exif = getExif(uri.toString());
-          exif.putString(
-            "DateTimeModified",
-            queryResult.getString(
-              queryResult.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
-            )
-          );
-          exif.putString(
-            "ImageOrientation",
-            queryResult.getString(
-              queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-            )
-          );
-
+          try {
+            exif.putString(
+              "DateTimeModified",
+              queryResult.getString(
+                queryResult.getColumnIndex(
+                  MediaStore.Images.Media.DATE_MODIFIED
+                )
+              )
+            );
+            exif.putString(
+              "ImageOrientation",
+              queryResult.getString(
+                queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+              )
+            );
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
           file.putMap("exif", exif);
-
-          File tempFile = new File(filePath);
-          long fileSize = tempFile.length();
-          file.putInt("fileSize", Math.toIntExact(fileSize));
 
           files.putMap(Integer.toString(index), file);
 
@@ -294,6 +304,7 @@ public class ReceiveSharingIntentHelper {
         }
       }
     }
+
     return files;
   }
 
@@ -320,6 +331,7 @@ public class ReceiveSharingIntentHelper {
 
       return exifMap;
     } catch (Exception e) {
+      e.printStackTrace();
       WritableMap exifMap = new WritableNativeMap();
       return exifMap;
     }


### PR DESCRIPTION
Added try catch to queries for `DATE_MODIFIED` and `ORIENTATION`. The issue seems to be somewhere in querying SQLite DB for Exif on the device. It's possible I didn't implement it correctly, and the [documentations](https://developer.android.com/reference/android/media/ExifInterface) mention that some issues are known on certain versions on Android. The only similar issue thread I could find was this - https://issuetracker.google.com/issues/149515829

Updated the library to AndroidX ExifInterface as recommended in the documentation. Let me know if you think this will cause issues on some devices.

Additionally, updated getting fileSize since it's received from `OpenableColumns`.