### PR TITLE
Update media exif resolving on Android & clear files on iOS

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -210,23 +210,8 @@ public class ReceiveSharingIntentHelper {
       file.putString("weblink", null);
       file.putString("subject", subject);
 
-      WritableMap exif = getExif(contentUri.toString());
-      try {
-        exif.putString(
-          "DateTimeModified",
-          queryResult.getString(
-            queryResult.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
-          )
-        );
-        exif.putString(
-          "ImageOrientation",
-          queryResult.getString(
-            queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-          )
-        );
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      WritableMap exif = getMediaExif(contentUri.toString(), queryResult);
+
       file.putMap("exif", exif);
 
       files.putMap("0", file);
@@ -274,25 +259,8 @@ public class ReceiveSharingIntentHelper {
           file.putString("weblink", null);
           file.putString("subject", subject);
 
-          WritableMap exif = getExif(uri.toString());
-          try {
-            exif.putString(
-              "DateTimeModified",
-              queryResult.getString(
-                queryResult.getColumnIndex(
-                  MediaStore.Images.Media.DATE_MODIFIED
-                )
-              )
-            );
-            exif.putString(
-              "ImageOrientation",
-              queryResult.getString(
-                queryResult.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-              )
-            );
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
+          WritableMap exif = getMediaExif(uri.toString(), queryResult);
+
           file.putMap("exif", exif);
 
           files.putMap(Integer.toString(index), file);
@@ -327,6 +295,52 @@ public class ReceiveSharingIntentHelper {
       exifMap.putString("originalUri", uri);
 
       return exifMap;
+    } catch (Exception e) {
+      e.printStackTrace();
+      WritableMap exifMap = new WritableNativeMap();
+      return exifMap;
+    }
+  }
+
+  // TODO: Expand with MediaMetadataRetriever for video metadata
+  // https://developer.android.com/reference/android/media/MediaMetadataRetriever
+  public WritableMap getMediaExif(String uri, Cursor queryCursor) {
+    try {
+      WritableMap exif = getExif(uri);
+
+      exif.putString(
+        "width",
+        queryCursor.getString(
+          queryCursor.getColumnIndex(MediaStore.Images.Media.WIDTH)
+        )
+      );
+      exif.putString(
+        "height",
+        queryCursor.getString(
+          queryCursor.getColumnIndex(MediaStore.Images.Media.HEIGHT)
+        )
+      );
+      // DATE_TAKEN is in miliseconds
+      Long dateTaken =
+        queryCursor.getLong(
+          queryCursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
+        ) /
+        1000;
+      exif.putString("DateTimeTaken", dateTaken.toString());
+      exif.putString(
+        "DateTimeModified",
+        queryCursor.getString(
+          queryCursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
+        )
+      );
+      exif.putString(
+        "ImageOrientation",
+        queryCursor.getString(
+          queryCursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+        )
+      );
+
+      return exif;
     } catch (Exception e) {
       e.printStackTrace();
       WritableMap exifMap = new WritableNativeMap();

--- a/src/ReceiveSharingIntent.ts
+++ b/src/ReceiveSharingIntent.ts
@@ -45,7 +45,12 @@ class ReceiveSharingIntentModule implements IReceiveSharingIntent {
   clearReceivedFiles() {
     // https://github.com/ajith-ab/react-native-receive-sharing-intent/issues/149
     // this.isClear = true;
-    ReceiveSharingIntent.clearFileNames();
+
+    // TODO: Clearing file names on iOS causes 
+    // new files not being received until the app is restarted
+    if (!this.isIos) {
+      ReceiveSharingIntent.clearFileNames();
+    }
   }
 
   protected getFileNames(


### PR DESCRIPTION
Updated exif resolving to use MediaStore columns for all necessary values.
I didn't notice in the documentation at first, but MediaStore is the superset of Exif interface and Media metadata, and it properly resolves for both photos and videos, while Exif resolves only for photos.
In the future it would be nice to either extend the usage of Media metadata, or use MediaStore for all common properties photos and videos have.

Disabled `clearFileNames` so I can test behaviour on builds. Removing values from user defaults on release builds seems to cause something that disables sharing intent modal to be shown again. It works properly again only after restarting the app.