### PR TITLE
CELPHO-000 Fix Android app opening

### DIFF
--- a/src/useSharingIntent.ts
+++ b/src/useSharingIntent.ts
@@ -62,6 +62,10 @@ export function useSharingIntent(
         }
       );
 
+      // Running getFileNames here allows us to handle the case
+      // when app is opened via sharing intent but wasn't previously opened
+      getFileNames('');
+
       return () => {
         listener?.remove();
       };


### PR DESCRIPTION
Fixed Android apps not properly getting files in case app wasn't opened in the background at all, the AppState listener isn't triggered at all in that scenario, so the change handler doesn't get invoked.

This was also how it was done in the old implementation, but I missed it when rewriting to hook.