### PR TITLE
Add error logs for `getFileNames`

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -114,7 +114,11 @@ public class ReceiveSharingIntentHelper {
         files.putMap("0", file);
         promise.resolve(files);
       } else {
-        promise.reject("error", "Invalid file type.");
+        WritableMap errorInfo = new WritableNativeMap();
+        WritableMap fileInfo = new WritableNativeMap();
+        fileInfo.putString("userInfo", action + "" + type);
+        errorInfo.putMap("fileInfo", fileInfo);
+        promise.reject("error", "file type is Invalid", errorInfo);
       }
     } catch (Exception e) {
       promise.reject("error", e.toString());

--- a/ios/ReceiveSharingIntent.swift
+++ b/ios/ReceiveSharingIntent.swift
@@ -20,8 +20,13 @@ class ReceiveSharingIntent: NSObject {
                       ) -> Void {
         let fileUrl = URL(string: url)
         let json =  handleUrl(url: fileUrl);
-        if(json == "error"){
-            let error = NSError(domain: "", code: 400, userInfo: nil)
+        if (json == "error"){
+            let appDomain = Bundle.main.bundleIdentifier!
+            let userDefaults = UserDefaults(suiteName: "group.\(appDomain)")
+            let key = fileUrl?.host?.components(separatedBy: "=").last ?? ""
+            let fileInfo = userDefaults?.object(forKey: key) as? Any ?? fileUrl as Any
+            let errorInfo = ["fileInfo": fileInfo]
+            let error = NSError(domain: "", code: 400, userInfo: errorInfo)
             reject("message", "file type is Invalid", error);
         }else if(json == "invalid group name"){
             let error = NSError(domain: "", code: 400, userInfo: nil)

--- a/src/useSharingIntent.ts
+++ b/src/useSharingIntent.ts
@@ -40,7 +40,7 @@ export function useSharingIntent(
             getFileNames(res);
           }
         })
-        .catch(() => {});
+        .catch((e: any) => errorHandler(e));
 
       const listener: any = Linking.addEventListener('url', (res: any) => {
         const url = res ? res.url : '';
@@ -70,5 +70,5 @@ export function useSharingIntent(
         listener?.remove();
       };
     }
-  }, [getFileNames, protocol]);
+  }, [getFileNames, errorHandler, protocol]);
 }


### PR DESCRIPTION
Feature adds additional data we have to error logging for `getFileNames`.
I was not able to reproduce issue in debug mode, so I would like to add logs to help with debugging builds, since there are still Sentry errors with this.