### PR TITLE
Update file type is Invalid error userInfo object

### DIFF
--- a/ios/ReceiveSharingIntent.swift
+++ b/ios/ReceiveSharingIntent.swift
@@ -24,8 +24,11 @@ class ReceiveSharingIntent: NSObject {
             let appDomain = Bundle.main.bundleIdentifier!
             let userDefaults = UserDefaults(suiteName: "group.\(appDomain)")
             let key = fileUrl?.host?.components(separatedBy: "=").last ?? ""
-            let fileInfo = userDefaults?.object(forKey: key) as? Any ?? fileUrl as Any
-            let errorInfo = ["fileInfo": fileInfo]
+            let fileInfo = userDefaults?.object(forKey: key)
+            var errorInfo = [String: Any]()
+            errorInfo["key"] = key
+            errorInfo["fileUrl"] = url
+            errorInfo["fileInfo"] = fileInfo
             let error = NSError(domain: "", code: 400, userInfo: errorInfo)
             reject("message", "file type is Invalid", error);
         }else if(json == "invalid group name"){


### PR DESCRIPTION
Fix adds some more information to error `userInfo` object, `key` and `fileUrl` can tell us how the link that opened the app looked like, and `fileInfo` represents all the file information we have stored in user defaults, which should give us more info about the metadata of the received file.